### PR TITLE
Add compile workflow

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -17,5 +17,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: release
+          name: sys-hidplus
           path: release/release_*.zip

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,21 @@
+name: Compile
+
+on:
+  workflow_dispatch:
+
+jobs:
+  compile:
+    name: Compile release archive
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Compile sysmodule
+        run: docker-compose run compile
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release
+          path: release/release_*.zip

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Compile sysmodule
-        run: docker-compose run compile
+        run: docker compose run compile
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,6 +1,9 @@
 name: Compile
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds a GitHub Action for convenience to build new release archives. The action will either trigger on pushes to master, or can be triggered manually.