### PR TITLE
Bump libnx to 4.7.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM devkitpro/devkita64:20220216
+FROM devkitpro/devkita64:20240916
 
 ARG BASE_PATH="atmosphere/contents/4200000000001312"
 


### PR DESCRIPTION
Bumps the libnx version to 4.7.0. Supposedly the sysmodule still works even on 18.1.0, but I'm pushing this out in case I, or anyone else, wants to future-proof it a bit ahead of time.

I needed to account for the following changes:
- [libnx 4.5.0](https://github.com/switchbrew/libnx/blob/master/Changelog.md#devices): Socket wrapper now selects latest available BSD service version
- [libnx 4.3.0](https://github.com/switchbrew/libnx/blob/master/Changelog.md#devices): `hiddbgAttachHdlsWorkBuffer` now requires us to pass in a memory buffer and size

These changes have _not_ been tested yet and may result in a crash.